### PR TITLE
 feat: separate git user from strap user 

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,7 @@ Adds scripting support to configure items or install things that do not fit well
 This is designed to work with [strap](https://github.com/MikeMcQuaid/strap) using the [scripts to rule them all pattern](https://github.com/github/scripts-to-rule-them-all).
 
 ## Supported environment variables
-* `GITHUB_HOST`: the host for git to find repositories (default: `github.com`)
+* `GIT_HOST`: the host for git to find repositories (default: `github.com`)
+* `GIT_USER`: the user to use for git (default: `$USER`)
 * `STRAP_GITHUB_HOST`: the github host to look under for repos these scripts depend on. (default: `github.com`)
 * `STRAP_GITHUB_USER`: the github user/org to look under for repos these scripts depend on (default: `gr8routdoors`)

--- a/script/configure-hub
+++ b/script/configure-hub
@@ -1,2 +1,5 @@
+# Strap by default sets user to the same user you're getting config from
+git config --global github.user "$GITHUB_USER"
+
 # Configures hub for custom github enterprise hosts
-git config --global --add hub.host "$GITHUB_HOST"
+git config --global hub.host "$GITHUB_HOST"

--- a/script/configure-hub
+++ b/script/configure-hub
@@ -1,5 +1,5 @@
 # Strap by default sets user to the same user you're getting config from
-git config --global github.user "$GITHUB_USER"
+git config --global github.user "$GIT_USER"
 
 # Configures hub for custom github enterprise hosts
-git config --global hub.host "$GITHUB_HOST"
+git config --global hub.host "$GIT_HOST"

--- a/script/strap-after-setup
+++ b/script/strap-after-setup
@@ -7,8 +7,9 @@ cd $(dirname $0)/..
 export STRAP_GITHUB_HOST=${STRAP_GITHUB_HOST:="github.com"}
 export STRAP_GITHUB_USER=${STRAP_GITHUB_USER:="gr8routdoors"}
 
-# The location to use for the hub github host (for GH enterprise)
+# Support different settings for github enterprise
 export GITHUB_HOST=${GITHUB_HOST:="github.com"}
+export GITHUB_USER=${GITHUB_USER:=$STRAP_GITHUB_USER}
 
 script/configure-hub
 script/install-oh-my-zsh

--- a/script/strap-after-setup
+++ b/script/strap-after-setup
@@ -8,8 +8,8 @@ export STRAP_GITHUB_HOST=${STRAP_GITHUB_HOST:="github.com"}
 export STRAP_GITHUB_USER=${STRAP_GITHUB_USER:="gr8routdoors"}
 
 # Support different settings for github enterprise
-export GITHUB_HOST=${GITHUB_HOST:="github.com"}
-export GITHUB_USER=${GITHUB_USER:=$STRAP_GITHUB_USER}
+export GIT_HOST=${GIT_HOST:="github.com"}
+export GIT_USER=${GIT_USER:=$USER}
 
 script/configure-hub
 script/install-oh-my-zsh


### PR DESCRIPTION
Strap by default sets user to the same user you're getting config from, which doesn't work if you're trying to share config across users.

